### PR TITLE
 Replaced outdated variable to enable registration (fixes #87)

### DIFF
--- a/account.php
+++ b/account.php
@@ -211,7 +211,7 @@ if ( $Request['Path'] === $Canonical ) {
 				exit;
 
 			// Register Check
-		} else if ( !$Sitewide['Signups']  ) {
+			} else if ( !$Sitewide['Signups']  ) {
 				require $Templates['Header'];
 				echo '<h2>Sorry, new Registrations are not allowed at this time.</h2>';
 				require $Templates['Footer'];

--- a/account.php
+++ b/account.php
@@ -211,7 +211,7 @@ if ( $Request['Path'] === $Canonical ) {
 				exit;
 
 			// Register Check
-			} else if ( !$Sitewide_Signups ) {
+		} else if ( !$Sitewide['Signups']  ) {
 				require $Templates['Header'];
 				echo '<h2>Sorry, new Registrations are not allowed at this time.</h2>';
 				require $Templates['Footer'];


### PR DESCRIPTION
In account.php , the line
} else if ( !$Sitewide_Signups ) {
replaced with
} else if ( !$Sitewide['Signups'] ) {